### PR TITLE
Move smartctl_version to back

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -163,9 +163,8 @@ format_output() {
 
 smartctl_version="$(/usr/sbin/smartctl -V | head -n1 | awk '$1 == "smartctl" {print $2}')"
 
-echo "smartctl_version{version=\"${smartctl_version}\"} 1" | format_output
-
 if [[ "$(expr "${smartctl_version}" : '\([0-9]*\)\..*')" -lt 6 ]]; then
+  echo "smartctl_version{version=\"${smartctl_version}\"} 0" | format_output
   exit
 fi
 
@@ -195,3 +194,5 @@ for device in ${device_list}; do
     ;;
   esac
 done | format_output
+
+echo "smartctl_version{version=\"${smartctl_version}\"} 1" | format_output


### PR DESCRIPTION
I had to move smartctl_version to the back because the delay caused by the loop resulted in the output not beeing written for me. Also changed the smartctl_version to "0" when version is < 6.