### PR TITLE
Feat: use systemd output redirection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,8 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/env bash ${SMARTMON_PATH}/smartmon.sh > /var/lib/node_exporter/textfile_collector/smart_metrics.prom
+ExecStart=/usr/bin/env bash ${SMARTMON_PATH}/smartmon.sh
+StandardOutput=truncate:/var/lib/node_exporter/textfile_collector/smart_metrics.prom
 WorkingDirectory=/var/lib/node_exporter/textfile_collector/
 
 [Install]


### PR DESCRIPTION
When using the service unit as generated, the output was not written to the intended file, but to the journal. Apparently, output redirection does not work for systemd units in this way. Luckily, there's the `StandardOutput` configuration option.

See [here](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#StandardOutput=) for more information.